### PR TITLE
PR: support salt portal 1.0.2 and release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+[0.2.0] - Unreleased
+- Add support for python 3.14
+- Drop support for python 3.9 and 3.10
+- Update to support salt portal 1.0.2
+- Update database schema to version 2 to support new outputs from salt portal. Most importantly:
+  - Flag for upstream probes
+  - Mass of salt and cft used per measurement
+- Update dependencies
+- Use ruff for code formatting
+
 [0.1.1] - 2025-01-14
 
 - Drop support for python 3.8

--- a/README.md
+++ b/README.md
@@ -23,13 +23,28 @@ connected with Fathom Scientific Ltd, the provider of the Salt Portal.
 - [Database schema](#database-schema)
 - [License](#license)
 
-## Installation as package
+## Installation
 
+The recommended way to install the package is using [uv](https://docs.astral.sh/uv/).
+
+As a standalone CLI tool (isolated environment, globally available):
+```console
+uv tool install salt-portal-backup
+```
+
+After installing with uv tool install, the CLI command is available globally without activating any virtual environment.
+
+The package can be installed in your current python environment using uv with:
+```console
+uv add salt-portal-backup
+```
+
+or, if you want to install it in your current python environment using pip:
 ```console
 pip install salt-portal-backup
 ```
 
-### Usage in python code
+### Usage in Python code
 
 ```python
 from salt_portal_backup import run_backup
@@ -49,11 +64,13 @@ run_backup(username='myusername', password='mypassword',
 
 ### Usage as CLI
 
-Run in the environment where salt-portal-backup is installed:
+Run:
 
 ```console
-python -m salt_portal_backup.backup --help
+salt_portal_backup --help
 ```
+
+Remember to activate the virtual environment where you installed the package if not installing globally with `uv tool install`.
 
 ## Download Windows executable
 
@@ -61,7 +78,7 @@ A windows stand-alone executable made with pyinstaller is available under [Relea
 
 ### Usage CLI
 
-Interaction with the CLI is the same was when calling the python script.
+Interaction with the CLI is the same as when calling the python script.
 
 ```console
 salt_portal_backup.exe --help
@@ -94,26 +111,20 @@ salt_portal_backup.exe
 Salt Portal username: myusername
 Salt Portal password: (input is hidden)
 Backup to C:\Users\myusername\salt_portal_20240826_135932.db
- projects:  33%|████████████████████████▎                                                | 3/9 [01:25<02:31, 25.22s/it]
- station in project:  12%|███████▉                                                       | 1/8 [00:01<00:11,  1.66s/it]
+ project (project name):  33%|████████████████████████▎                                                | 3/9 [01:25<02:31, 25.22s/it]
+ station (station name):  12%|███████▉                                                       | 1/8 [00:01<00:11,  1.66s/it]
  measurement at station:  34%|███████████████████▍                                     | 17/50 [00:10<00:16,  1.96it/s]
 ```
 
 ## Limitations
 
-- Rating curves are currently not stored in the backup database
-- Information on upstream probes is partially missing (i.e. not marked as upstream probe, group often missing, 
-no info on probe used in which calculations)
+- Rating curves are currently not stored in the backup database, but this is planned for a future release.
 
 ## Building the pyinstaller exe
 
 ```console
 pyinstaller src/salt_portal_backup/backup.py --onefile --name salt_portal_backup --icon static/icon-256.ico
 ```
-
-## Database schema
-
-![erd_v1](static/salt_portal_db_v1.png)
 
 ## License
 

--- a/examples/example_python_code.py
+++ b/examples/example_python_code.py
@@ -1,8 +1,7 @@
-
 """
-Example calling the python code for performing backup
+Example calling the Python code for performing backup
 
-Note: it is not recommend storing login credetials in python code
+Note: it is not recommended to store login credentials in Python code
 Use, for example, environmental variables and .env files instead
 """
 
@@ -12,10 +11,9 @@ from salt_portal_backup import run_backup
 # backup will be stored in the user home directory
 # with name salt_portal_yyyymmdd_hhmmss.db where yyyymmdd_hhmmss
 # is the current date and time
-run_backup(username='myusername', password='mypassword')
+run_backup(username="myusername", password="mypassword")
 
 # provide location for the backup adding database_path keyword
 # example below will create the my_backup.db database in the current
 # working directory of the python session
-run_backup(username='myusername', password='mypassword', 
-           database_path='my_backup.db')
+run_backup(username="myusername", password="mypassword", database_path="my_backup.db")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "salt-portal-backup"
-dynamic = ["version"]
+version = "0.2.0"
 description = 'Backup projects, stations, calibrations and measurements from Salt Portal to a SQLite database.'
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "salt-portal-backup"
 dynamic = ["version"]
 description = 'Backup projects, stations, calibrations and measurements from Salt Portal to a SQLite database.'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = "BSD-3-Clause"
 keywords = []
 authors = [
@@ -16,23 +16,22 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
 dependencies = [
-"sqlalchemy",
-"beautifulsoup4",
-"pandas",
-"numpy",
-"requests",
-"click",
-"tqdm"
+    "sqlalchemy>=2.0.37",
+    "beautifulsoup4>=4.14.0",
+    "pandas>=3.0.0",
+    "numpy>=2.4.0",
+    "requests>=2.32.3",
+    "click>=8.3.0",
+    "tqdm>=4.67.1"
 ]
 
 [project.urls]
@@ -43,38 +42,40 @@ Source = "https://github.com/rhkarls/salt-portal-backup"
 [project.scripts]
 salt_portal_backup = "salt_portal_backup.backup:main"
 
-[tool.hatch.version]
-path = "src/salt_portal_backup/__about__.py"
-
-[tool.hatch.envs.types]
-extra-dependencies = [
-  "mypy>=1.0.0",
+[tool.ruff]
+line-length = 88
+lint.select = [
+  "B", # flake8-bugbear rules
+  "E", # pycodestyle error rules
+  "F", # pyflakes rules
+  "I", # isort rules
+  "W", # pycodestyle warning rules
 ]
-[tool.hatch.envs.types.scripts]
-check = "mypy --install-types --non-interactive {args:src/salt_portal_backup tests}"
-
-[tool.coverage.run]
-source_pkgs = ["salt_portal_backup", "tests"]
-branch = true
-parallel = true
-omit = [
-  "src/salt_portal_backup/__about__.py",
+lint.ignore = [
+  "E501", # line-too-long
 ]
 
-[tool.coverage.paths]
-salt_portal_backup = ["src/salt_portal_backup", "*/salt-portal-backup/src/salt_portal_backup"]
-tests = ["tests", "*/salt-portal-backup/tests"]
+[tool.uv]
+default-groups = [ "dev"]
 
-[tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
+[tool.numpydoc_validation]
+checks = [
+  "all",  # report on all checks
+  "ES01", # but don't require an extended summary
+  "EX01", # or examples
+  "SA01", # or a see also section
+  "SS06", # and don't require the summary to fit on one line
+]
+exclude = [ # don't report on checks for these
+  '\\.__init__$',
+  '\\.__repr__$',
+  '\\.__str__$',
 ]
 
 [dependency-groups]
 dev = [
-    "build>=1.2.2.post1",
-    "pyinstaller>=6.11.1",
-    "twine>=6.0.1",
+    "build>=1.4.3",
+    "pyinstaller>=6.19.0",
+    "ruff>=0.15.11",
+    "twine>=6.2.0",
 ]

--- a/src/salt_portal_backup/__init__.py
+++ b/src/salt_portal_backup/__init__.py
@@ -2,4 +2,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from .salt_portal import run_backup
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("salt-portal-backup")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+from .salt_portal import run_backup as run_backup
+

--- a/src/salt_portal_backup/__init__.py
+++ b/src/salt_portal_backup/__init__.py
@@ -10,4 +10,3 @@ except PackageNotFoundError:
     __version__ = "unknown"
 
 from .salt_portal import run_backup as run_backup
-

--- a/src/salt_portal_backup/backup.py
+++ b/src/salt_portal_backup/backup.py
@@ -4,16 +4,16 @@
 
 import click
 
+from salt_portal_backup import __version__
 from salt_portal_backup.salt_portal import run_backup
-from salt_portal_backup.__about__ import __version__
 
 
 @click.command(
     help="""
-    Backup projects, stations, calibrations and measurements from Salt Portal 
+    Backup projects, stations, calibrations and measurements from Salt Portal
     to a SQLite database.
     \b
-    
+
     BSD-3-Clause License\n
     Copyright (c) 2024-present Reinert Huseby Karlsen <rhkarls@proton.me>
     """

--- a/src/salt_portal_backup/database.py
+++ b/src/salt_portal_backup/database.py
@@ -47,7 +47,9 @@ class Measurement(Base):
     measurement_id: Mapped[int] = mapped_column(primary_key=True)
     station_id: Mapped[int] = mapped_column(ForeignKey("station.id"))
     station: Mapped["Station"] = relationship(back_populates="measurements")
-    group_id: Mapped[int] = mapped_column(ForeignKey("measurement_group.id"), nullable=True)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("measurement_group.id"), nullable=True
+    )
     group: Mapped["MeasurementGroup"] = relationship(back_populates="measurements")
     datetime_start: Mapped[str] = mapped_column(TEXT)
     datetime_end: Mapped[str] = mapped_column(TEXT)
@@ -73,7 +75,7 @@ class Measurement(Base):
     sd_file_id: Mapped[int] = mapped_column(nullable=True)
     sdiq_mass_nacl_kg: Mapped[float] = mapped_column(nullable=True)
     sdiq_cft: Mapped[float] = mapped_column(nullable=True)
-    #states: Mapped[str] = mapped_column(TEXT, nullable=True)
+    # states: Mapped[str] = mapped_column(TEXT, nullable=True)
     csv_data: Mapped["MeasurementCSVData"] = relationship(back_populates="measurement")
 
 
@@ -168,7 +170,9 @@ def initialize_database(database_name: str = None) -> sqlalchemy.Engine:
         )  # FIXME can we do create_engine without str concat?
 
     elif Path(database_name).exists():
-        raise NotImplementedError("Database file already exists. Backup to existing database is not implemented yet.")
+        raise NotImplementedError(
+            "Database file already exists. Backup to existing database is not implemented yet."
+        )
         print(
             "Database file already exists. It is recommended to backup to a new database. "
             "Proceed with existing database, possibly leading to data loss of already existing data?"

--- a/src/salt_portal_backup/database.py
+++ b/src/salt_portal_backup/database.py
@@ -2,25 +2,17 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""
-TODO: control schema against .sql
-"""
-
 from datetime import datetime
 from pathlib import Path
 
-from sqlalchemy.orm import relationship
-
-from sqlalchemy import ForeignKey, CheckConstraint
-from sqlalchemy import create_engine
+import sqlalchemy
+from sqlalchemy import CheckConstraint, ForeignKey, create_engine
 from sqlalchemy.dialects.sqlite import (
     TEXT,
 )  # not strictly necessary since sqlite use type affinity, but makes the type explicit
-from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-DATABASE_VERSION = 1
+DATABASE_VERSION = 2
 
 
 class Base(DeclarativeBase): ...
@@ -46,19 +38,20 @@ class Station(Base):
 class Project(Base):
     __tablename__ = "project"
     id: Mapped[int] = mapped_column(primary_key=True)
-    name: Mapped[str] = mapped_column(TEXT)
+    project_name: Mapped[str] = mapped_column(TEXT)
     stations: Mapped["Station"] = relationship(back_populates="project")
 
 
 class Measurement(Base):
     __tablename__ = "measurement"
-    id: Mapped[int] = mapped_column(primary_key=True)
+    measurement_id: Mapped[int] = mapped_column(primary_key=True)
     station_id: Mapped[int] = mapped_column(ForeignKey("station.id"))
     station: Mapped["Station"] = relationship(back_populates="measurements")
     group_id: Mapped[int] = mapped_column(ForeignKey("measurement_group.id"), nullable=True)
     group: Mapped["MeasurementGroup"] = relationship(back_populates="measurements")
-    datetime: Mapped[str] = mapped_column(TEXT)
+    datetime_start: Mapped[str] = mapped_column(TEXT)
     datetime_end: Mapped[str] = mapped_column(TEXT)
+    upstream_probe: Mapped[bool] = mapped_column()
     flow_cms: Mapped[float] = mapped_column()
     uncertainty_percent: Mapped[float] = mapped_column()
     notes: Mapped[str] = mapped_column(TEXT, nullable=True)
@@ -74,15 +67,20 @@ class Measurement(Base):
     ref_stage_m: Mapped[float] = mapped_column(nullable=True)
     type: Mapped[str] = mapped_column(TEXT, nullable=True)
     filename: Mapped[str] = mapped_column(TEXT)
+    channel_name: Mapped[str] = mapped_column(TEXT, nullable=True)
     rating_curve_ids: Mapped[str] = mapped_column(TEXT, nullable=True)
-    states: Mapped[str] = mapped_column(TEXT, nullable=True)
+    probe_serial_number: Mapped[str] = mapped_column(TEXT, nullable=True)
+    sd_file_id: Mapped[int] = mapped_column(nullable=True)
+    sdiq_mass_nacl_kg: Mapped[float] = mapped_column(nullable=True)
+    sdiq_cft: Mapped[float] = mapped_column(nullable=True)
+    #states: Mapped[str] = mapped_column(TEXT, nullable=True)
     csv_data: Mapped["MeasurementCSVData"] = relationship(back_populates="measurement")
 
 
 class MeasurementCSVData(Base):
     __tablename__ = "measurement_csv_data"
     measurement_id: Mapped[int] = mapped_column(
-        ForeignKey("measurement.id"), primary_key=True
+        ForeignKey("measurement.measurement_id"), primary_key=True
     )  # Should be 1-to-1, TODO OK? better to use separate id to make sure?
     measurement: Mapped["Measurement"] = relationship(back_populates="csv_data")
     csv_data: Mapped[str] = mapped_column(TEXT)
@@ -121,6 +119,7 @@ class Version(Base):
     id: Mapped[int] = mapped_column(CheckConstraint("id = 0"), primary_key=True)
     database_version: Mapped[int] = mapped_column()
     salt_portal_version: Mapped[str] = mapped_column(TEXT)
+    salt_portal_backup_version: Mapped[str] = mapped_column(TEXT)
     datetime_created: Mapped[str] = mapped_column(TEXT)
     created_by_user: Mapped[str] = mapped_column(TEXT)
 
@@ -152,17 +151,27 @@ class CalibrationRaw(Base):
     station_raw_calibration_data: Mapped[str] = mapped_column(TEXT)
 
 
-def initialize_database(database_name: str = None) -> create_engine:
+def initialize_database(database_name: str = None) -> sqlalchemy.Engine:
+    """Initialize the SQLite database for the backup.
+
+    If a database name is provided, it will be used, otherwise a new database will be
+    created in the users home folder with a name based on the current date and time.
+
+    If a database with the provided name already exists, a warning is printed and the
+    existing database is used (TODO implement).
+    """
+
     if database_name is None:
         db_filename = "salt_portal_" + datetime.now().strftime("%Y%m%d_%H%M%S") + ".db"
         database_name = str(
             Path.home() / db_filename
         )  # FIXME can we do create_engine without str concat?
 
-    if Path(database_name).exists():
+    elif Path(database_name).exists():
+        raise NotImplementedError("Database file already exists. Backup to existing database is not implemented yet.")
         print(
             "Database file already exists. It is recommended to backup to a new database. "
-            "Proceed with existing database, possiblity leading to data loss of already existing data?"
+            "Proceed with existing database, possibly leading to data loss of already existing data?"
         )
         # TODO implement
 

--- a/src/salt_portal_backup/salt_portal.py
+++ b/src/salt_portal_backup/salt_portal.py
@@ -29,8 +29,16 @@ from .database import (
 
 SUPPORTED_SP_VERSION = "1.0.2"
 
+DESC_WIDTH = 34
 
-def run_backup(username, password, database_path=None):
+def _fmt_desc(text: str, width: int = DESC_WIDTH) -> str:
+    if len(text) > width:
+        text = text[:width - 1] + "…"
+    return text.ljust(width)
+
+def run_backup(username: str,
+               password: str,
+               database_path: str | Path | None = None):
 
     db_engine = initialize_database(database_name=database_path)
 
@@ -86,10 +94,12 @@ def run_backup(username, password, database_path=None):
         header_station_measurements = header_data_template.copy()
         header_station_page = header_data_template.copy()
 
-        for _, project in tqdm(
-            projects.iterrows(), desc=" projects", total=projects.shape[0], position=0
-        ):
+        projects_iter = tqdm(projects.iterrows(),
+                             total=projects.shape[0],
+                             position=0)
+        for _, project in projects_iter:
             project_name = project["project_name"]
+            projects_iter.set_description(_fmt_desc(f" project ({project_name})"))
             project_id = project["project_id"]
 
             project_insert = Project(**{"id": project_id, "project_name": project_name})
@@ -99,14 +109,13 @@ def run_backup(username, password, database_path=None):
 
             stations_in_project = stations[stations["project_id"] == project_id]
 
-            for _, station in tqdm(
-                stations_in_project.iterrows(),
-                desc=" station in project",
-                total=stations_in_project.shape[0],
-                leave=False,
-                position=1,
-            ):
+            stations_iter = tqdm(stations_in_project.iterrows(),
+                                 total=stations_in_project.shape[0],
+                                 position=1,
+                                 leave=False)
+            for _, station in stations_iter:
                 station_name = station["station_name"]
+                stations_iter.set_description(_fmt_desc(f" station ({station_name})"))
                 station_id = station["station_id"]
 
                 header_station_measurements["Referer"] = (
@@ -140,7 +149,7 @@ def run_backup(username, password, database_path=None):
                 # download and insert each measurement_data_csv in corresponding table
                 for mi, md in tqdm(
                     measurements.iterrows(),
-                    desc=" measurement at station",
+                    desc=_fmt_desc(" measurement at station"),
                     total=measurements.shape[0],
                     leave=False,
                     position=2,

--- a/src/salt_portal_backup/salt_portal.py
+++ b/src/salt_portal_backup/salt_portal.py
@@ -2,43 +2,54 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import re
 import datetime
+import re
+import warnings
+from pathlib import Path
 
-from bs4 import BeautifulSoup as bs
-import requests
 import numpy as np
+import requests
+from bs4 import BeautifulSoup as bs
+from sqlalchemy.orm import Session
 from tqdm import tqdm
 
 from salt_portal_backup import __version__ as spb_version
 
-from .database import initialize_database, DATABASE_VERSION
 from .database import (
+    DATABASE_VERSION,
     Calibration,
     CalibrationRaw,
     Measurement,
-    MeasurementRaw,
+    MeasurementCSVData,
     MeasurementGroup,
+    MeasurementRaw,
+    Project,
     Station,
     StationListRaw,
-    Project,
-    MeasurementCSVData,
     # RatingCurve,
     Version,
+    initialize_database,
+)
+from .web_scraping import (
+    URL_LOGIN,
+    get_projects_stations,
+    get_station_data,
+    header_data_template,
+    login_salt_portal,
 )
 
 SUPPORTED_SP_VERSION = "1.0.2"
 
 DESC_WIDTH = 34
 
+
 def _fmt_desc(text: str, width: int = DESC_WIDTH) -> str:
     if len(text) > width:
-        text = text[:width - 1] + "…"
+        text = text[: width - 1] + "…"
     return text.ljust(width)
 
-def run_backup(username: str,
-               password: str,
-               database_path: str | Path | None = None):
+
+def run_backup(username: str, password: str, database_path: str | Path | None = None):
 
     db_engine = initialize_database(database_name=database_path)
 
@@ -50,27 +61,35 @@ def run_backup(username: str,
         login_res = login_salt_portal(s_request, token, username, password)
 
         html_main_page = bs(login_res.text, "html.parser")
-        if html_main_page.find("li", string=re.compile("Successfully signed in")) is None:
+        if (
+            html_main_page.find("li", string=re.compile("Successfully signed in"))
+            is None
+        ):
             raise Exception("Login failed")
 
         html_sidenav = html_main_page.find("div", class_="wh-sidenav-content")
         full_version_tag = html_sidenav.find("p", string=re.compile("Salt Portal "))
-        sp_semver = full_version_tag.text.strip().lstrip("Salt Portal ")
+        sp_semver = full_version_tag.text.strip().removeprefix("Salt Portal ")
 
         if sp_semver != SUPPORTED_SP_VERSION:
-            warnings.warn(f"The current version of Salt Portal Backup that you are using (package version {spb_version}), is not "
-                          f"tested against the Salt Portal version that is currently live on the interweb ({sp_semver}). This may cause issues "
-                          f"with the backup, as the data schema may change. Supported "
-                          f"Salt Portal version is {SUPPORTED_SP_VERSION}."
-                          f"\n\nPlease check for updates of the Salt Portal Backup package, "
-                          f"and if no updates are available please submit an issue at https://github.com/rhkarls/salt-portal-backup/issues "
-                          f"and include the versions printed in this message.", stacklevel=2)
+            warnings.warn(
+                f"The current version of Salt Portal Backup that you are using (package version {spb_version}), is not "
+                f"tested against the Salt Portal version that is currently live on the interweb ({sp_semver}). This may cause issues "
+                f"with the backup, as the data schema may change. Supported "
+                f"Salt Portal version is {SUPPORTED_SP_VERSION}."
+                f"\n\nPlease check for updates of the Salt Portal Backup package, "
+                f"and if no updates are available please submit an issue at https://github.com/rhkarls/salt-portal-backup/issues "
+                f"and include the versions printed in this message.",
+                stacklevel=2,
+            )
 
         db_version = Version(
             id=0,
             database_version=DATABASE_VERSION,
             salt_portal_version=sp_semver,
-            datetime_created=datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds"),
+            datetime_created=datetime.datetime.now(datetime.UTC).isoformat(
+                timespec="seconds"
+            ),
             created_by_user=username,
             salt_portal_backup_version=spb_version,
         )
@@ -79,7 +98,9 @@ def run_backup(username: str,
         s_db.commit()
 
         # set the token for all the headers in this session
-        header_data_template["Cookie"] = header_data_template["Cookie"].format(token=token)
+        header_data_template["Cookie"] = header_data_template["Cookie"].format(
+            token=token
+        )
 
         header_get_organization = header_data_template.copy()
         projects, stations, stations_csv = get_projects_stations(
@@ -94,9 +115,7 @@ def run_backup(username: str,
         header_station_measurements = header_data_template.copy()
         header_station_page = header_data_template.copy()
 
-        projects_iter = tqdm(projects.iterrows(),
-                             total=projects.shape[0],
-                             position=0)
+        projects_iter = tqdm(projects.iterrows(), total=projects.shape[0], position=0)
         for _, project in projects_iter:
             project_name = project["project_name"]
             projects_iter.set_description(_fmt_desc(f" project ({project_name})"))
@@ -109,10 +128,12 @@ def run_backup(username: str,
 
             stations_in_project = stations[stations["project_id"] == project_id]
 
-            stations_iter = tqdm(stations_in_project.iterrows(),
-                                 total=stations_in_project.shape[0],
-                                 position=1,
-                                 leave=False)
+            stations_iter = tqdm(
+                stations_in_project.iterrows(),
+                total=stations_in_project.shape[0],
+                position=1,
+                leave=False,
+            )
             for _, station in stations_iter:
                 station_name = station["station_name"]
                 stations_iter.set_description(_fmt_desc(f" station ({station_name})"))
@@ -137,17 +158,19 @@ def run_backup(username: str,
                 s_db.add(station_insert)
 
                 # Get the measurements and calibrations of a station
-                measurements_csv, measurements, calibrations_csv, calibrations = get_station_data(
-                    s_request,
-                    project_id,
-                    station_id,
-                    header_station_measurements,
-                    header_station_page,
+                measurements_csv, measurements, calibrations_csv, calibrations = (
+                    get_station_data(
+                        s_request,
+                        project_id,
+                        station_id,
+                        header_station_measurements,
+                        header_station_page,
+                    )
                 )
 
                 # loop over measurements, insert each measurement and
                 # download and insert each measurement_data_csv in corresponding table
-                for mi, md in tqdm(
+                for _mi, md in tqdm(
                     measurements.iterrows(),
                     desc=_fmt_desc(" measurement at station"),
                     total=measurements.shape[0],
@@ -190,18 +213,24 @@ def run_backup(username: str,
                         }
                     )
                     measurement_csv_insert = MeasurementCSVData(
-                        **{"measurement_id": md["ID"], "csv_data": measurement_data_csv.content}
+                        **{
+                            "measurement_id": md["ID"],
+                            "csv_data": measurement_data_csv.content,
+                        }
                     )
 
                     s_db.add(measurement_insert)
                     s_db.add(measurement_csv_insert)
 
                 measurement_raw_insert = MeasurementRaw(
-                    **{"station_id": station_id, "station_raw_measurement_data": measurements_csv}
+                    **{
+                        "station_id": station_id,
+                        "station_raw_measurement_data": measurements_csv,
+                    }
                 )
                 s_db.add(measurement_raw_insert)
 
-                for cal_i, cal_d in calibrations.iterrows():
+                for _cal_i, cal_d in calibrations.iterrows():
                     calibration_insert = Calibration(
                         **{
                             "id": cal_d["ID"],
@@ -217,7 +246,9 @@ def run_backup(username: str,
                             "volume_distilled_water_calibration_l": cal_d[
                                 "Volume of Distilled H20 used in calibration."
                             ],
-                            "mass_salt_calibration_mg": cal_d["Mass of salt used in calibration."],
+                            "mass_salt_calibration_mg": cal_d[
+                                "Mass of salt used in calibration."
+                            ],
                             "volume_stream_water_calibration_l": cal_d[
                                 "Volume of H20 from stream used in calibration."
                             ],
@@ -236,7 +267,10 @@ def run_backup(username: str,
                     s_db.add(calibration_insert)
 
                 calibration_raw_insert = CalibrationRaw(
-                    **{"station_id": station_id, "station_raw_calibration_data": calibrations_csv}
+                    **{
+                        "station_id": station_id,
+                        "station_raw_calibration_data": calibrations_csv,
+                    }
                 )
                 s_db.add(calibration_raw_insert)
 
@@ -244,15 +278,15 @@ def run_backup(username: str,
                 groups = [int(x) for x in set(measurements["group"]) if ~np.isnan(x)]
                 group_inserts = []
                 for group in groups:
-                    group_csv_link = (
-                        f"https://wit.fathomscientific.com/group-measurement/{group}/csv-download"
-                    )
+                    group_csv_link = f"https://wit.fathomscientific.com/group-measurement/{group}/csv-download"
                     group_csv_data = s_request.get(
                         group_csv_link, headers=header_station_measurements
                     )
 
                     group_inserts.append(
-                        MeasurementGroup(**{"id": group, "group_summary": group_csv_data.content})
+                        MeasurementGroup(
+                            **{"id": group, "group_summary": group_csv_data.content}
+                        )
                     )
 
                 s_db.add_all(group_inserts)

--- a/src/salt_portal_backup/salt_portal.py
+++ b/src/salt_portal_backup/salt_portal.py
@@ -10,13 +10,7 @@ import requests
 import numpy as np
 from tqdm import tqdm
 
-from .web_scraping import URL_LOGIN, header_data_template
-from .web_scraping import (
-    login_salt_portal,
-    get_projects_stations,
-    get_station_data,
-    get_station_groups,
-)
+from salt_portal_backup import __version__ as spb_version
 
 from .database import initialize_database, DATABASE_VERSION
 from .database import (
@@ -33,7 +27,7 @@ from .database import (
     Version,
 )
 
-from sqlalchemy.orm import Session
+SUPPORTED_SP_VERSION = "1.0.2"
 
 
 def run_backup(username, password, database_path=None):
@@ -55,12 +49,22 @@ def run_backup(username, password, database_path=None):
         full_version_tag = html_sidenav.find("p", string=re.compile("Salt Portal "))
         sp_semver = full_version_tag.text.strip().lstrip("Salt Portal ")
 
+        if sp_semver != SUPPORTED_SP_VERSION:
+            warnings.warn(f"The current version of Salt Portal Backup that you are using (package version {spb_version}), is not "
+                          f"tested against the Salt Portal version that is currently live on the interweb ({sp_semver}). This may cause issues "
+                          f"with the backup, as the data schema may change. Supported "
+                          f"Salt Portal version is {SUPPORTED_SP_VERSION}."
+                          f"\n\nPlease check for updates of the Salt Portal Backup package, "
+                          f"and if no updates are available please submit an issue at https://github.com/rhkarls/salt-portal-backup/issues "
+                          f"and include the versions printed in this message.", stacklevel=2)
+
         db_version = Version(
             id=0,
             database_version=DATABASE_VERSION,
             salt_portal_version=sp_semver,
             datetime_created=datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds"),
             created_by_user=username,
+            salt_portal_backup_version=spb_version,
         )
 
         s_db.add(db_version)
@@ -88,7 +92,7 @@ def run_backup(username, password, database_path=None):
             project_name = project["project_name"]
             project_id = project["project_id"]
 
-            project_insert = Project(**{"id": project_id, "name": project_name})
+            project_insert = Project(**{"id": project_id, "project_name": project_name})
 
             s_db.add(project_insert)
             s_db.commit()
@@ -147,11 +151,12 @@ def run_backup(username, password, database_path=None):
 
                     measurement_insert = Measurement(
                         **{
-                            "id": md["ID"],
+                            "measurement_id": md["ID"],
                             "station_id": station_id,
                             "group_id": md["group"],
-                            "datetime": md["Date of Q Measurement"],
+                            "datetime_start": md["Date of Q Measurement"],
                             "datetime_end": md["End time of Q Measurement"],
+                            "upstream_probe": md["IsUpstream"],
                             "flow_cms": md["Flow (cms)"],
                             "uncertainty_percent": md["Measurement Uncertainty"],
                             "notes": md["Notes"],
@@ -167,8 +172,12 @@ def run_backup(username, password, database_path=None):
                             "ref_stage_m": md["Ref Stage (m)"],
                             "type": md["Type"],
                             "filename": md["Filename"],
-                            "rating_curve_ids": md["RatingCurveIds"],
-                            "states": md["States"],
+                            "sd_file_id": md["SDFile_ID"],
+                            "sdiq_mass_nacl_kg": md["SDIQ - Mass NaCl"],
+                            "sdiq_cft": md["SDIQ - CFT"],
+                            "channel_name": md["Channel Name"],
+                            "rating_curve_ids": md["Rating Curve ID"],
+                            "probe_serial_number": md["Probe Serial Number"],
                         }
                     )
                     measurement_csv_insert = MeasurementCSVData(

--- a/src/salt_portal_backup/web_scraping.py
+++ b/src/salt_portal_backup/web_scraping.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re
-from io import BytesIO
 from datetime import datetime
+from io import BytesIO
 
-from bs4 import BeautifulSoup as bs
-import pandas as pd
-
-# import polars as pl
 import numpy as np
+import pandas as pd
+from bs4 import BeautifulSoup as bs
 
 URL_LOGIN = "https://wit.fathomscientific.com/accounts/login/"
 
@@ -70,7 +68,9 @@ def get_projects_stations(s_request, header_organization):
         "https://wit.fathomscientific.com/station-cfts/", headers=header_organization
     )
 
-    station_csv_header = b"station_name,station_id,project_name,project_id,cft_1,cft_2,cft_3\r\n"
+    station_csv_header = (
+        b"station_name,station_id,project_name,project_id,cft_1,cft_2,cft_3\r\n"
+    )
     stations = pd.read_csv(BytesIO(station_csv_header + station_csv.content))
     # stations_pl = pl.read_csv(BytesIO(station_csv_header + station_csv.content))
 
@@ -86,10 +86,18 @@ def get_station_data(
     """Retrieve measurement and calibration info and data for a specific station"""
 
     calibrations_csv, calibrations = get_station_calibrations(
-        s_request, project_id, station_id, header_station_measurements, header_station_page
+        s_request,
+        project_id,
+        station_id,
+        header_station_measurements,
+        header_station_page,
     )
     measurements_csv, measurements = get_station_measurements(
-        s_request, project_id, station_id, header_station_measurements, header_station_page
+        s_request,
+        project_id,
+        station_id,
+        header_station_measurements,
+        header_station_page,
     )
 
     return measurements_csv, measurements, calibrations_csv, calibrations
@@ -114,10 +122,13 @@ def get_station_calibrations(
     # the Exception below, also include match on filename.
     calibrations["ID"] = pd.array([pd.NA] * calibrations.shape[0], dtype="Int64")
 
-    header_station_page["Referer"] = f"https://wit.fathomscientific.com/project/{project_id}/"
+    header_station_page["Referer"] = (
+        f"https://wit.fathomscientific.com/project/{project_id}/"
+    )
 
     station_page_get = s_request.get(
-        f"https://wit.fathomscientific.com/station/{station_id}/", headers=header_station_page
+        f"https://wit.fathomscientific.com/station/{station_id}/",
+        headers=header_station_page,
     )
 
     station_html = bs(station_page_get.text, "html.parser")
@@ -172,10 +183,13 @@ def get_station_measurements(
     download_base = "https://wit.fathomscientific.com"
     measurements["download_link"] = None
 
-    header_station_page["Referer"] = f"https://wit.fathomscientific.com/project/{project_id}/"
+    header_station_page["Referer"] = (
+        f"https://wit.fathomscientific.com/project/{project_id}/"
+    )
 
     station_page_get = s_request.get(
-        f"https://wit.fathomscientific.com/station/{station_id}/", headers=header_station_page
+        f"https://wit.fathomscientific.com/station/{station_id}/",
+        headers=header_station_page,
     )
 
     station_html = bs(station_page_get.text, "html.parser")
@@ -195,12 +209,14 @@ def get_station_measurements(
                     if "download" in td_link["href"]:
                         csv_dl_partial_link = td_link["href"]
 
-                        match = re.search(r"/measurement/(\d+)/update", td_links[0]["href"])
+                        match = re.search(
+                            r"/measurement/(\d+)/update", td_links[0]["href"]
+                        )
                         measurement_id = int(match.group(1))
 
-                        measurements.loc[measurements["ID"] == measurement_id, "download_link"] = (
-                            download_base + csv_dl_partial_link
-                        )
+                        measurements.loc[
+                            measurements["ID"] == measurement_id, "download_link"
+                        ] = download_base + csv_dl_partial_link
 
     return measurements_csv.content, measurements
 
@@ -208,7 +224,9 @@ def get_station_measurements(
 def get_station_groups(s, header_station_measurements, measurements):
     groups = [int(x) for x in set(measurements["group"]) if ~np.isnan(x)]
     for group in groups:
-        group_csv_link = f"https://wit.fathomscientific.com/group-measurement/{group}/csv-download"
+        group_csv_link = (
+            f"https://wit.fathomscientific.com/group-measurement/{group}/csv-download"
+        )
         group_csv_data = s.get(group_csv_link, headers=header_station_measurements)
 
     # don't need the dataframe where, csv data is not returned with a fixed strucutre


### PR DESCRIPTION
This PR adds support for the current salt portal version 1.0.2

It also includes some general CLI formatting improvements and reformatted and lint code using ruff.

Closes the following issues:
#6 
#5 
#4 
#8 